### PR TITLE
modify:Organisation admin login

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -25,7 +25,7 @@ class Auth::SessionsController < Devise::SessionsController
     self.resource = warden.authenticate!(auth_options)
 
     if main_channel?
-      if user_admin_login_invalid?(resource)
+      if login_blocked_for?(resource) 
         handle_invalid_user_login(resource)
         return
       end
@@ -209,21 +209,39 @@ class Auth::SessionsController < Devise::SessionsController
     end
   end
 
-  def user_admin_login_invalid?(user)
-    user.role&.name.in?(%w[UserAdmin HubAdmin]) || user.role.id == -99 || user.role.id.nil? ? !handle_user_login(user) : false
+  def login_blocked_for?(user)
+    invalid_organisation_login?(user) || invalid_admin_login?(user)
   end
 
-  def handle_user_login(user)
-    return false unless user&.account_id
+  def invalid_admin_login?(user)
+    return false unless has_special_role?(user, %w[UserAdmin HubAdmin])
 
-    Community.joins(:community_admins).exists?(
-      community_admins: {
-      account_id: user.account_id,
-      role: ['UserAdmin', 'HubAdmin'],
-      is_boost_bot: true,
-      account_status: CommunityAdmin.account_statuses["active"]
-      }
-    )
+    !has_valid_community_admin?(user, roles: %w[UserAdmin HubAdmin], boost_bot: true)
+  end
+
+  def invalid_organisation_login?(user)
+    return false unless has_special_role?(user, %w[OrganisationAdmin])
+    
+    !has_valid_community_admin?(user, roles: %w[OrganisationAdmin], boost_bot: true)
+  end
+
+  def has_special_role?(user, role_names)
+    return false unless user.present? && user.role.present?
+
+    user.role.id == -99 || user.role.id.nil? || role_names.include?(user.role.name)
+  end
+
+  def has_valid_community_admin?(user, roles:, boost_bot:)
+    return false unless user.account_id.present?
+
+    Community.joins(:community_admins)
+             .where(community_admins: {
+               account_id: user.account_id,
+               role: roles,
+               is_boost_bot: boost_bot,
+               account_status: CommunityAdmin.account_statuses["active"]
+             })
+             .exists?
   end
   
   def handle_invalid_user_login(user)

--- a/app/helpers/channel_helper.rb
+++ b/app/helpers/channel_helper.rb
@@ -2,6 +2,9 @@
 
 module ChannelHelper
   def main_channel?
+    if Rails.env.local? || Rails.env.test?
+      return true
+    end
     ENV.fetch('MAIN_CHANNEL', nil) != nil && ENV.fetch('MAIN_CHANNEL', nil) != 'false'
   end
 end


### PR DESCRIPTION
### Organisation admin login from channel.org
- Organisation admins and User admins who are boost bot account able to login. Hub admins won't be able to login via channel.org mastodon Web UI.
- Mobile: Only boost bot will be able to login.
- Web: Organisation and Hub admins won't be able to login.

### Related Backlog Issue
[Do not allow sub-sequent admins to login to channel.org system](https://binary-lab.backlog.com/view/NM-1259)

### Checklist
- [x] Code has been tested locally.